### PR TITLE
Optimizing native code

### DIFF
--- a/core/ffmpeg/build.gradle.kts
+++ b/core/ffmpeg/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         consumerProguardFiles("consumer-rules.pro")
         externalNativeBuild {
             cmake {
-                cppFlags("-DCMAKE_CXX_FLAGS=-frtti -fexceptions -Wno-deprecated-declaration")
+                cppFlags("-DCMAKE_CXX_FLAGS=-frtti -fexceptions -Wno-deprecated-declaration -std=c++23")
             }
         }
     }

--- a/core/ffmpeg/src/main/cpp/CMakeLists.txt
+++ b/core/ffmpeg/src/main/cpp/CMakeLists.txt
@@ -31,9 +31,17 @@ add_library(swscale STATIC IMPORTED)
 set_target_properties(swscale PROPERTIES IMPORTED_LOCATION ${ffmpeg_lib_dir}/libswscale.so)
 
 # 4、你的 native 库
-add_library(${CMAKE_PROJECT_NAME} SHARED
-        ffmpeg_utils.cpp
-)
+
+file(GLOB_RECURSE BILI_AS_FFMPEG_SOURCES "src/*.cpp")
+#file(GLOB_RECURSE BILI_AS_FFMPEG_MODULES "src/*.ixx")
+
+add_library(${CMAKE_PROJECT_NAME} SHARED ${BILI_AS_FFMPEG_SOURCES})
+
+#target_sources(${CMAKE_PROJECT_NAME} PRIVATE
+#        FILE_SET CXX_MODULES
+#        TYPE CXX_MODULES
+#        FILES ${BILI_AS_FFMPEG_MODULES}
+#)
 
 
 # 5、链接静态库和安卓常用库

--- a/core/ffmpeg/src/main/cpp/src/ffmpeg_free.hpp
+++ b/core/ffmpeg/src/main/cpp/src/ffmpeg_free.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "traits.hpp"
+
+extern "C" {
+#include "libavformat/avformat.h"
+}
+
+namespace bilias::ffmpeg {
+
+    class FFMPEGFree {
+    public:
+
+        auto operator()(AVFormatContext *ctx) const noexcept -> void {
+            if (ctx) {
+                avformat_free_context(ctx);
+            }
+        }
+    };
+
+    using AVFormatContextPtr = std::unique_ptr<AVFormatContext, FFMPEGFree>;
+
+    inline auto bilias_avformat_alloc_output_context2(
+        const AVOutputFormat *oformat,
+        const char *format_name,
+        const char *filename
+    ) noexcept -> std::pair<AVFormatContextPtr, int> {
+        AVFormatContext *temp{nullptr};
+        auto ret = avformat_alloc_output_context2(&temp, oformat, format_name, filename);
+        return {AVFormatContextPtr(temp), ret};
+    }
+
+} // namespace bilias::ffmpeg

--- a/core/ffmpeg/src/main/cpp/src/traits.hpp
+++ b/core/ffmpeg/src/main/cpp/src/traits.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <concepts>
+
+namespace bilias::ffmpeg {
+
+    template<typename F>
+    requires std::is_invocable_v<F>
+    struct Defer {
+        F f;
+        explicit Defer(F &&f) noexcept : f(std::move(f)) {}
+
+        ~Defer() noexcept(noexcept(f())) {
+            f();
+        }
+    };
+} // namespace bilias::ffmpeg


### PR DESCRIPTION
-  Cache jni class/method to struct FFmpegMergeListener
- Use Defer to free jni string
- Use FFMPEGFree to free ctx