### PR TITLE
fix: Series 的 series_ord 字段允许为空

### DIFF
--- a/core/network/src/main/java/com/imcys/bilibilias/network/model/user/BILIUserBangumiFollowInfo.kt
+++ b/core/network/src/main/java/com/imcys/bilibilias/network/model/user/BILIUserBangumiFollowInfo.kt
@@ -334,7 +334,7 @@ data class BILIUserBangumiFollowInfo(
             @SerialName("series_id")
             val seriesId: Long,
             @SerialName("series_ord")
-            val seriesOrd: Long,
+            val seriesOrd: Long?,
             @SerialName("title")
             val title: String
         )


### PR DESCRIPTION
参考以下请求返回：
<img width="372" height="194" alt="10eee130b8efedaa5328d2bd70d8b7e6" src="https://github.com/user-attachments/assets/c6fef29b-6894-452f-9c43-8c89206016b8" />
